### PR TITLE
Don't crash if mapper times out

### DIFF
--- a/dbusUtils.hpp
+++ b/dbusUtils.hpp
@@ -38,6 +38,11 @@ std::string getService(sdbusplus::bus::bus& bus, const std::string& path,
             // The service isn't on D-Bus yet.
             return std::string{};
         }
+        else if (ex.name() == std::string("org.freedesktop.DBus.Error.Timeout"))
+        {
+            lg2::info("Mapper timeout while looking up {PATH}", "PATH", path);
+            return std::string{};
+        }
 
         throw;
     }


### PR DESCRIPTION
We've seen cases where there is so much going on at once on a system that the mapper will get too busy and calls to it will time out.

When this happens to virtual-sensors it will core dump and restart, but eventually over time it can accumulate so many restarts that it will hit systemd's restart limit and no longer be restarted.

To avoid this, just do the same thing as when the sensor isn't on D-Bus, which is to ignore that sensor for now and try again the next time the virtual sensor is calculated.

Change-Id: I6a09fe4c56070f1b23c97f66fe38f3b900e02ee9
Signed-off-by: Matt Spinler <spinler@us.ibm.com>