### PR TITLE
Add missing lg2 include

### DIFF
--- a/dbusUtils.hpp
+++ b/dbusUtils.hpp
@@ -1,4 +1,5 @@
 #include <phosphor-logging/elog-errors.hpp>
+#include <phosphor-logging/lg2.hpp>
 #include <xyz/openbmc_project/Common/error.hpp>
 
 const char* propIntf = "org.freedesktop.DBus.Properties";


### PR DESCRIPTION
This wasn't needed in the upstream commit "Don't crash if mapper times out" since there were other lg2 calls in the file already so I missed it.

Change-Id: Ia82ca79420bf61dc9ae2c80eba3778b55aef6b62
Signed-off-by: Matt Spinler <spinler@us.ibm.com>